### PR TITLE
changing to fString for filepath

### DIFF
--- a/ValueFinder.py
+++ b/ValueFinder.py
@@ -78,7 +78,7 @@ class VF_OT_value_finder(bpy.types.Operator):
             slope = (props.end_input-props.start_input)/(props.steps-1)
             value = props.start_input+slope*step
             input_socket.default_value = value
-            rd.filepath = original_path + "-" + str(step+1) + "({} = {})".format(input_socket.name,value)
+            rd.filepath = f"{original_path}-{str(step+1)}({input_socket.name} = {value})"
             bpy.ops.render.render(write_still = True)
         rd.filepath = original_path
         

--- a/ValueFinder.py
+++ b/ValueFinder.py
@@ -106,7 +106,7 @@ class VF_OT_value_finder(bpy.types.Operator):
             if props.image_info:
                 rd.filepath = f"{original_path}_({input_socket.name}_{step+1:n}={value:.2f})"
             else:
-                rd.filepath = original_path + str(step+1)
+                rd.filepath = f"{original_path}{step+1:n}"
             bpy.ops.render.render(write_still = True)
         # Restore the originals
         rd.filepath = original_path


### PR DESCRIPTION
f"{original_path}-{str(step+1)}({input_socket.name} = {value})"
is a more readable string that uses one type of string formatting.