### PR TITLE
Math Formula: "arrange from root" improvements

### DIFF
--- a/math_formula/__init__.py
+++ b/math_formula/__init__.py
@@ -49,7 +49,7 @@ class MFMathFormula(bpy.types.AddonPreferences):
     node_distance: bpy.props.IntProperty(
         name="Distance between nodes",
         description="The distance placed between the nodes from the formula",
-        default=10,
+        default=20,
         min=0,
     )
     sibling_distance: bpy.props.IntProperty(
@@ -224,13 +224,15 @@ kmi_defs = [
     # kmi_defs entry: (identifier, key, action, CTRL, SHIFT, ALT, props)
     # props entry: (property name, property value)
     (main.MF_OT_arrange_from_root.bl_idname,
-     'E', 'PRESS', False, False, True, None),
+     'E', 'PRESS', False, False, False, (('selected_only', False),)),
+    (main.MF_OT_arrange_from_root.bl_idname,
+     'E', 'PRESS', False, False, True, (('selected_only', True),)),
     (main.MF_OT_select_from_root.bl_idname,
-     'E', 'PRESS', True, True, False, (('select_children', True), ('select_parents', True))),
+     'K', 'PRESS', False, False, False, (('select_children', True), ('select_parents', True))),
     (main.MF_OT_select_from_root.bl_idname,
-     'E', 'PRESS', True, False, False, (('select_children', True), ('select_parents', False))),
+     'K', 'PRESS', True, False, False, (('select_children', True), ('select_parents', False))),
     (main.MF_OT_select_from_root.bl_idname,
-     'E', 'PRESS', False, True, False, (('select_children', False), ('select_parents', True))),
+     'K', 'PRESS', False, True, False, (('select_children', False), ('select_parents', True))),
     (main.MF_OT_type_formula_then_add_nodes.bl_idname,
      'F', 'PRESS', False, False, True, None),
 ]

--- a/math_formula/__init__.py
+++ b/math_formula/__init__.py
@@ -224,9 +224,13 @@ kmi_defs = [
     # kmi_defs entry: (identifier, key, action, CTRL, SHIFT, ALT, props)
     # props entry: (property name, property value)
     (main.MF_OT_arrange_from_root.bl_idname,
-     'E', 'PRESS', False, False, False, (('selected_only', False),)),
+     'E', 'PRESS', False, False, False, (('selected_only', False), ('invert_relations', False))),
     (main.MF_OT_arrange_from_root.bl_idname,
-     'E', 'PRESS', False, False, True, (('selected_only', True),)),
+     'E', 'PRESS', False, False, True, (('selected_only', True), ('invert_relations', False))),
+    (main.MF_OT_arrange_from_root.bl_idname,
+     'E', 'PRESS', False, True, False, (('selected_only', False), ('invert_relations', True))),
+    (main.MF_OT_arrange_from_root.bl_idname,
+     'E', 'PRESS', False, True, True, (('selected_only', True), ('invert_relations', True))),
     (main.MF_OT_select_from_root.bl_idname,
      'K', 'PRESS', False, False, False, (('select_children', True), ('select_parents', True))),
     (main.MF_OT_select_from_root.bl_idname,

--- a/math_formula/main.py
+++ b/math_formula/main.py
@@ -98,6 +98,12 @@ class MF_OT_arrange_from_root(bpy.types.Operator):
         description="Only arrange nodes that are selected",
         default=False,
     )  # type: ignore
+    
+    invert_relations: bpy.props.BoolProperty(
+        name="Invert Relations",
+        description="Invert the relations between parents and children",
+        default=False,
+    )  # type: ignore
 
     def execute(self, context: bpy.types.Context):
         space = cast(bpy.types.SpaceNodeEditor, context.space_data)
@@ -108,7 +114,7 @@ class MF_OT_arrange_from_root(bpy.types.Operator):
         active_node.select = True
         # Figure out the parents, children, and siblings of nodes.
         # Needed for the node positioner
-        node_positioner = TreePositioner(context, selected_only=self.selected_only)
+        node_positioner = TreePositioner(context, selected_only=self.selected_only, invert_relations=self.invert_relations)
         node_positioner.place_nodes(active_node, links)
         return {'FINISHED'}
 

--- a/math_formula/main.py
+++ b/math_formula/main.py
@@ -93,15 +93,22 @@ class MF_OT_arrange_from_root(bpy.types.Operator):
     def poll(cls, context: bpy.types.Context) -> bool:
         return mf_check(context) and context.active_node is not None
 
+    selected_only: bpy.props.BoolProperty(
+        name="Selected Only",
+        description="Only arrange nodes that are selected",
+        default=False,
+    )  # type: ignore
+
     def execute(self, context: bpy.types.Context):
         space = cast(bpy.types.SpaceNodeEditor, context.space_data)
         links = space.edit_tree.links
         active_node = context.active_node
-        bpy.ops.node.select_all(action='DESELECT')
+        if not self.selected_only:
+            bpy.ops.node.select_all(action='DESELECT')
         active_node.select = True
         # Figure out the parents, children, and siblings of nodes.
         # Needed for the node positioner
-        node_positioner = TreePositioner(context)
+        node_positioner = TreePositioner(context, selected_only=self.selected_only)
         node_positioner.place_nodes(active_node, links)
         return {'FINISHED'}
 

--- a/math_formula/positioning.py
+++ b/math_formula/positioning.py
@@ -1,6 +1,6 @@
 from sys import maxsize as INF
 from typing import cast, Optional
-from bpy.types import Node, NodeLinks
+from bpy.types import Node, NodeLinks, Context
 from mathutils import Vector
 
 
@@ -139,11 +139,12 @@ class TreePositioner():
     Algorithm: https://www.cs.unc.edu/techreports/89-034.pdf
     """
 
-    def __init__(self, context):
+    def __init__(self, context: Context, selected_only =  False):
         prefs = context.preferences.addons['math_formula'].preferences
         self.level_separation: int = prefs.node_distance
         self.sibling_separation: int = prefs.sibling_distance
         self.subtree_separation: int = prefs.subtree_distance
+        self.selected_only = selected_only
         self.x_top_adjustment: int = 0
         self.y_top_adjustment: int = 0
         self.max_width_per_level: list[int] = [0 for _ in range(100)]
@@ -167,6 +168,8 @@ class TreePositioner():
                 add_link = True
                 child = None
                 from_node = link.from_node
+                if self.selected_only and not from_node.select:
+                    continue
                 for ilink, _ in input_links:
                     if ilink.from_node == from_node:
                         add_link = False


### PR DESCRIPTION
Enhances the functionality of the `node.mf_arrange_from_root` operator. It now has options for limiting to the selection, and for arranging the "other way". See below for more details:

This changes the shortcuts for arranging and selecting nodes in the following way:
- <kbd>E</kbd> used for arranging nodes
  - <kbd>Alt (⌥ Option on Mac)</kbd> will limit the positioning to selected nodes only (and the active node)
  - <kbd>⇧ Shift</kbd> will arrange "parents" of the active node instead of children.
- <kbd>K</kbd> used for selecting nodes connected to the active node
  - <kbd>⇧ Shift</kbd> will limit to only selecting "parents"
  - <kbd>Ctrl (⌘ Command on Mac) </kbd> will limit to only selecting "children"

Fixes #19 